### PR TITLE
Fix: Unsigned integer handling and signed value error #1

### DIFF
--- a/src/Convertors/Convertor.cs
+++ b/src/Convertors/Convertor.cs
@@ -1,5 +1,7 @@
+using System.ComponentModel;
 using System.Text;
 using System.Numerics;
+using Panbyte.Exceptions;
 
 namespace Panbyte.Convertors;
 
@@ -69,10 +71,20 @@ public static class Convertor
 
     public static string ConvertToInt(byte[] input, Enums.Endianity endianity = Enums.Endianity.Big)
     {
+        if (input.Length > 4)
+        {
+            throw new UnsignedIntOverflowException("Input is too large to be converted to an unsigned integer.");
+        }
+        
         if (endianity == Enums.Endianity.Big)
         {
             Array.Reverse(input);
         }
-        return new BigInteger(input).ToString();
+        
+        byte[] paddedInput = new byte[4] { 0, 0, 0, 0 };
+        input.CopyTo(paddedInput, 0);
+        
+        uint output = BitConverter.ToUInt32(paddedInput, 0);
+        return output.ToString();
     }
 }

--- a/src/Convertors/InputConvertor.cs
+++ b/src/Convertors/InputConvertor.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Panbyte.Validators;
 using System.Text.RegularExpressions;
 using System.Numerics;
+using Panbyte.Exceptions;
 
 namespace Panbyte.Convertors;
 
@@ -20,6 +21,12 @@ public static partial class InputConvertor
     {
         byte[] result;
         result = input.ToByteArray();
+        
+        if (result.Length > 4)
+        {
+            throw new UnsignedIntOverflowException("Input is too big to be converted to an unsigned integer.");
+        }
+        
         if (inputEndianity == Endianity.Big)
         {
             Array.Reverse(result);

--- a/src/Exceptions/UnsignedIntOverflowException.cs
+++ b/src/Exceptions/UnsignedIntOverflowException.cs
@@ -1,0 +1,9 @@
+namespace Panbyte.Exceptions;
+
+public class UnsignedIntOverflowException : Exception
+{ 
+    public UnsignedIntOverflowException(string message) : base(message)
+    {
+        
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,3 +1,5 @@
+using Panbyte.Exceptions;
+
 namespace Panbyte;
 static class Program
 {
@@ -21,6 +23,11 @@ static class Program
             return 1;
         }
         catch (Exception e) when (e is FormatException || e is NotImplementedException)
+        {
+            Console.WriteLine(e.Message);
+            return 1;
+        }
+        catch (UnsignedIntOverflowException e)
         {
             Console.WriteLine(e.Message);
             return 1;

--- a/tests/Convertors/BitsConvertorTests.cs
+++ b/tests/Convertors/BitsConvertorTests.cs
@@ -1,3 +1,6 @@
+using Panbyte.Enums;
+using Panbyte.Exceptions;
+
 namespace Panbyte.Tests.Convertors;
 using Panbyte.Convertors;
 using Panbyte.Utils;
@@ -53,5 +56,29 @@ public class BitsConvertorTest
         string input = "100111101001011";
         string result = Convertor.ConvertToInt(InputConvertor.ConvertBits(input));
         Assert.AreEqual("20299", result);
+    }
+    
+    [TestMethod]
+    public void ConvertToIntSignedValue()
+    {
+        string input = "10000000";
+        string result = Convertor.ConvertToInt(InputConvertor.ConvertBits(input));
+        Assert.AreEqual("128", result);
+    }
+
+    [TestMethod]
+    public void ConvertToIntOverflow()
+    {
+        string input = "100000000000000000000000000000000";
+        Assert.ThrowsException<UnsignedIntOverflowException>(() =>
+            Convertor.ConvertToInt(InputConvertor.ConvertBits(input)));
+    }
+
+    [TestMethod]
+    public void ConvertToIntEdge()
+    {
+        string input = "11111111111111111111111111111111";
+        string result = Convertor.ConvertToInt(InputConvertor.ConvertBits(input));
+        Assert.AreEqual("4294967295", result);
     }
 }

--- a/tests/Convertors/ByteArrayConvertorTests.cs
+++ b/tests/Convertors/ByteArrayConvertorTests.cs
@@ -86,6 +86,4 @@ public class ByteArrayConvertorTest
         Assert.AreEqual(@"{'\x01', '\x02', '\x03', '\x04'}", result);
     }
 
-
-
 }

--- a/tests/Convertors/BytesConvertorTests.cs
+++ b/tests/Convertors/BytesConvertorTests.cs
@@ -49,28 +49,4 @@ public class BytesConvertorTest
         string result = Convertor.ConvertToInt(InputConvertor.ConvertBytes(input));
         Assert.AreEqual("1952805748", result);
     }
-
-    [TestMethod]
-    public void ConvertToIntSignedValue()
-    {
-        string input = "\u0080";
-        string result = Convertor.ConvertToInt(InputConvertor.ConvertBytes(input));
-        Assert.AreEqual("128", result);
-    }
-
-    [TestMethod]
-    public void ConvertToIntOverflow()
-    {
-        string input = "\u0001";
-        Assert.ThrowsException<UnsignedIntOverflowException>(() =>
-            Convertor.ConvertToInt(InputConvertor.ConvertBytes(input)));
-    }
-
-    [TestMethod]
-    public void ConvertToIntEdge()
-    {
-        string input = "ÿÿÿÿ";
-        string result = Convertor.ConvertToInt(InputConvertor.ConvertBytes(input));
-        Assert.AreEqual("4294967295", result);
-    }
 }

--- a/tests/Convertors/BytesConvertorTests.cs
+++ b/tests/Convertors/BytesConvertorTests.cs
@@ -1,5 +1,6 @@
 namespace Panbyte.Tests.Convertors;
 using Panbyte.Convertors;
+using Panbyte.Exceptions;
 using Panbyte.Utils;
 
 [TestClass]
@@ -47,5 +48,29 @@ public class BytesConvertorTest
         string input = "test";
         string result = Convertor.ConvertToInt(InputConvertor.ConvertBytes(input));
         Assert.AreEqual("1952805748", result);
+    }
+
+    [TestMethod]
+    public void ConvertToIntSignedValue()
+    {
+        string input = "\u0080";
+        string result = Convertor.ConvertToInt(InputConvertor.ConvertBytes(input));
+        Assert.AreEqual("128", result);
+    }
+
+    [TestMethod]
+    public void ConvertToIntOverflow()
+    {
+        string input = "\u0001";
+        Assert.ThrowsException<UnsignedIntOverflowException>(() =>
+            Convertor.ConvertToInt(InputConvertor.ConvertBytes(input)));
+    }
+
+    [TestMethod]
+    public void ConvertToIntEdge()
+    {
+        string input = "ÿÿÿÿ";
+        string result = Convertor.ConvertToInt(InputConvertor.ConvertBytes(input));
+        Assert.AreEqual("4294967295", result);
     }
 }

--- a/tests/Convertors/HexConvertorTests.cs
+++ b/tests/Convertors/HexConvertorTests.cs
@@ -1,5 +1,6 @@
 namespace Panbyte.Tests.Convertors;
 using Panbyte.Convertors;
+using Panbyte.Exceptions;
 using Panbyte.Utils;
 
 [TestClass]
@@ -63,5 +64,21 @@ public class HexConvertorTest
         string input = "d2029649";
         string result = Convertor.ConvertToInt(InputConvertor.ConvertHex(input), Enums.Endianity.Little);
         Assert.AreEqual("1234567890", result);
+    }
+
+    [TestMethod]
+    public void ConvertToIntSignedValue()
+    {
+        string input = "80";
+        string result = Convertor.ConvertToInt(InputConvertor.ConvertHex(input));
+        Assert.AreEqual("128", result);
+    }
+
+    [TestMethod]
+    public void ConvertToIntEdge()
+    {
+        string input = "FFFFFFFF";
+        string result = Convertor.ConvertToInt(InputConvertor.ConvertHex(input));
+        Assert.AreEqual("4294967295", result);
     }
 }

--- a/tests/Convertors/IntConvertorTests.cs
+++ b/tests/Convertors/IntConvertorTests.cs
@@ -1,3 +1,6 @@
+using System.Numerics;
+using Panbyte.Exceptions;
+
 namespace Panbyte.Tests.Convertors;
 using Panbyte.Convertors;
 using Panbyte.Enums;
@@ -56,5 +59,12 @@ public class IntConvertorTest
         string input = "1234567890";
         string result = Convertor.ConvertToInt(InputConvertor.ConvertInt(uint.Parse(input), Endianity.Big));
         Assert.AreEqual("1234567890", result);
+    }
+
+    [TestMethod]
+    public void ConvertBigInt()
+    {
+        var input = 12345678901234567890;
+        Assert.ThrowsException<UnsignedIntOverflowException>(() => Convertor.ConvertToInt(InputConvertor.ConvertInt(input, Endianity.Big)));
     }
 }


### PR DESCRIPTION
**First fixed issue:**
From our testing of your implementation, we discovered that you are not treating integers as unsigned. 

For example:
`echo ffff | dotnet run -- -f hex -t int`
Returns:
-1

This particular issue is connected with the first bit being 1. Therefore this issue is visible whenever you are converting to an unsigned integer and have a value like that.

We fixed this issue by removing the usage of BigInteger, which is signed, and replaced it with uint. We also wrote some tests to ensure our changes solved the issue.

We also discovered an issue with converting from integers bigger than unsigned integers. We think it should not be possible to do. There is also the fact that you are implicitly converting to unsigned integers in your tests. Therefore, it throws you some exceptions when trying to parse integers bigger than 32 bits. But in implementation, you were using BigInteger. 

![image](https://github.com/P3t0331/secure-coding-principles-project/assets/72571138/14d51039-a7b4-4e46-be7f-56c5f71b290a)


