### PR TITLE
fix: Printable characters handling in array to array conversion #2

### DIFF
--- a/src/Convertors/Convertor.cs
+++ b/src/Convertors/Convertor.cs
@@ -29,16 +29,17 @@ public static class Convertor
                     result.Append(ConvertToInt(inputArray, Enums.Endianity.Little));
                     break;
                 case Enums.ArrayFormat.Char:
+                    result.Append('\'');
                     if (inputArray[0] >= 32 && inputArray[0] <= 126)
                     {
                         result.Append(ConvertToBytes(inputArray));  
                     }
                     else
                     {
-                        result.Append("'\\x");
+                        result.Append("\\x");
                         result.Append(ConvertToHex(inputArray).AsSpan(0, 2));
-                        result.Append('\'');
                     }
+                    result.Append('\'');
                     break;
                 case Enums.ArrayFormat.Binary:
                     result.Append("0b");

--- a/tests/Convertors/NestedByteArrayTests.cs
+++ b/tests/Convertors/NestedByteArrayTests.cs
@@ -142,4 +142,29 @@ public class NestedByteArrayTest
         Assert.AreEqual("{0x1, 0x2, {0x5, {0x6, {0x7}, {0x8}, {0x9, 0xa}}, {0xb}, 0xc}, {0xd}}\r\n".Trim(), stringWriter.ToString().Trim());
     }
 
+    [TestMethod]
+    public void ConvertArrayToCharArray()
+    {
+        Structs.Arguments cliArgs = new Structs.Arguments(
+            inputFormat: Enums.Format.Array,
+            inputOptions: new List<string> { },
+            outputFormat: Enums.Format.Array,
+            outputOptions: new List<string> { @"a", "{" },
+            inputPath: null,
+            outputPath: null,
+            delimiter: null
+        );
+        
+        InputProcessor inputProcessor = new InputProcessor(cliArgs: cliArgs);
+        string input = @"{97}";
+        
+        StringReader stringReader = new StringReader(input);
+        Console.SetIn(stringReader);
+
+        StringWriter stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+        
+        inputProcessor.ProcessInput();
+        Assert.AreEqual("{'a'}\r\n".Trim(), stringWriter.ToString().Trim());
+    }
 }

--- a/tests/Convertors/NestedByteArrayTests.cs
+++ b/tests/Convertors/NestedByteArrayTests.cs
@@ -143,7 +143,7 @@ public class NestedByteArrayTest
     }
 
     [TestMethod]
-    public void ConvertArrayToCharArray()
+    public void ConvertArrayToCharArrayIntInput()
     {
         Structs.Arguments cliArgs = new Structs.Arguments(
             inputFormat: Enums.Format.Array,
@@ -166,5 +166,57 @@ public class NestedByteArrayTest
         
         inputProcessor.ProcessInput();
         Assert.AreEqual("{'a'}\r\n".Trim(), stringWriter.ToString().Trim());
+    }
+
+    [TestMethod]
+    public void ConvertArrayToCharArrayBitsInput()
+    {
+        Structs.Arguments cliArgs = new Structs.Arguments(
+            inputFormat: Enums.Format.Array,
+            inputOptions: new List<string> { },
+            outputFormat: Enums.Format.Array,
+            outputOptions: new List<string> { @"a", "{" },
+            inputPath: null,
+            outputPath: null,
+            delimiter: null
+        );
+
+        InputProcessor inputProcessor = new InputProcessor(cliArgs: cliArgs);
+        string input = @"{0b1100010}";
+
+        StringReader stringReader = new StringReader(input);
+        Console.SetIn(stringReader);
+
+        StringWriter stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+
+        inputProcessor.ProcessInput();
+        Assert.AreEqual("{'b'}\r\n".Trim(), stringWriter.ToString().Trim());
+    }
+
+    [TestMethod]
+    public void ConvertArrayToCharArrayHexInput()
+    {
+        Structs.Arguments cliArgs = new Structs.Arguments(
+            inputFormat: Enums.Format.Array,
+            inputOptions: new List<string> { },
+            outputFormat: Enums.Format.Array,
+            outputOptions: new List<string> { @"a", "{" },
+            inputPath: null,
+            outputPath: null,
+            delimiter: null
+        );
+
+        InputProcessor inputProcessor = new InputProcessor(cliArgs: cliArgs);
+        string input = @"{0x63}";
+
+        StringReader stringReader = new StringReader(input);
+        Console.SetIn(stringReader);
+
+        StringWriter stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+
+        inputProcessor.ProcessInput();
+        Assert.AreEqual("{'c'}\r\n".Trim(), stringWriter.ToString().Trim());
     }
 }


### PR DESCRIPTION
Another discovered issue is the wrong format of outputted printable characters in array-to-array conversion.

For example:
`echo "{97}" | dotnet run -- -f array -t array --to-options=a`
Returns:
`{a}`

But in the assignment is explicitly stated that all outputted bytes shall be enclosed in ' ' quotations marks. This could be useful if you want to convert the output of your program again. 
`echo "{'a'}" | dotnet run -- -f array -t array --to-options=a` results in `{a}` but your program only allows input in this format: `{'a'}`