### PR TITLE
fix: Array hex to hex conversion resolution #3

### DIFF
--- a/src/Convertors/Convertor.cs
+++ b/src/Convertors/Convertor.cs
@@ -23,7 +23,8 @@ public static class Convertor
             {
                 case Enums.ArrayFormat.Hex:
                     result.Append("0x");
-                    result.Append(ConvertToHex(inputArray).Replace("0", ""));
+                    var converted = ConvertToHex(inputArray);
+                    result.Append(converted.TrimStart('0'));
                     break;
                 case Enums.ArrayFormat.Decimal:
                     result.Append(ConvertToInt(inputArray, Enums.Endianity.Little));

--- a/src/Convertors/InputConvertor.cs
+++ b/src/Convertors/InputConvertor.cs
@@ -88,7 +88,7 @@ public static partial class InputConvertor
                 throw new FormatException("This input is not a valid byte array format: " + element);
             }
         }
-
+        
         return result.SelectMany(b => b).ToArray();
     }
 

--- a/src/Convertors/InputConvertor.cs
+++ b/src/Convertors/InputConvertor.cs
@@ -88,7 +88,7 @@ public static partial class InputConvertor
                 throw new FormatException("This input is not a valid byte array format: " + element);
             }
         }
-        
+
         return result.SelectMany(b => b).ToArray();
     }
 

--- a/tests/Convertors/NestedByteArrayTests.cs
+++ b/tests/Convertors/NestedByteArrayTests.cs
@@ -142,4 +142,18 @@ public class NestedByteArrayTest
         Assert.AreEqual("{0x1, 0x2, {0x5, {0x6, {0x7}, {0x8}, {0x9, 0xa}}, {0xb}, 0xc}, {0xd}}\r\n".Trim(), stringWriter.ToString().Trim());
     }
 
+    [TestMethod]
+    public void HexToHexWithTrailingZeroes()
+    {
+        string input = @"{0xf0}";
+
+        StringReader stringReader = new StringReader(input);
+        Console.SetIn(stringReader);
+
+        StringWriter stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+
+        defaultInputProcessor.ProcessInput();
+        Assert.AreEqual("{0xf0}", stringWriter.ToString().Trim());
+    }
 }

--- a/tests/Convertors/NestedByteArrayTests.cs
+++ b/tests/Convertors/NestedByteArrayTests.cs
@@ -143,7 +143,7 @@ public class NestedByteArrayTest
     }
 
     [TestMethod]
-    public void HexToHexWithTrailingZeroes()
+    public void HexToHexWithTrailingZero()
     {
         string input = @"{0xf0}";
 
@@ -155,5 +155,20 @@ public class NestedByteArrayTest
 
         defaultInputProcessor.ProcessInput();
         Assert.AreEqual("{0xf0}", stringWriter.ToString().Trim());
+    }
+
+    [TestMethod]
+    public void HexToHexWithStartingZero()
+    {
+        string input = @"{0x0f}";
+
+        StringReader stringReader = new StringReader(input);
+        Console.SetIn(stringReader);
+
+        StringWriter stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+
+        defaultInputProcessor.ProcessInput();
+        Assert.AreEqual("{0xf}", stringWriter.ToString().Trim());
     }
 }

--- a/tests/Convertors/NestedByteArrayTests.cs
+++ b/tests/Convertors/NestedByteArrayTests.cs
@@ -143,7 +143,7 @@ public class NestedByteArrayTest
     }
 
     [TestMethod]
-    public void HexToHexWithTrailingZero()
+    public void ArrayHexToHexWithTrailingZero()
     {
         string input = @"{0xf0}";
 
@@ -158,7 +158,7 @@ public class NestedByteArrayTest
     }
 
     [TestMethod]
-    public void HexToHexWithStartingZero()
+    public void ArrayHexToHexWithStartingZero()
     {
         string input = @"{0x0f}";
 
@@ -170,5 +170,35 @@ public class NestedByteArrayTest
 
         defaultInputProcessor.ProcessInput();
         Assert.AreEqual("{0xf}", stringWriter.ToString().Trim());
+    }
+
+    [TestMethod]
+    public void ArrayIntToHexWithTrailingZero()
+    {
+        string input = @"{240}";
+
+        StringReader stringReader = new StringReader(input);
+        Console.SetIn(stringReader);
+
+        StringWriter stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+
+        defaultInputProcessor.ProcessInput();
+        Assert.AreEqual("{0xf0}", stringWriter.ToString().Trim());
+    }
+
+    [TestMethod]
+    public void ArrayBitsToHexWithTrailingZero()
+    {
+        string input = @"{0b11110000}";
+
+        StringReader stringReader = new StringReader(input);
+        Console.SetIn(stringReader);
+
+        StringWriter stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+
+        defaultInputProcessor.ProcessInput();
+        Assert.AreEqual("{0xf0}", stringWriter.ToString().Trim());
     }
 }


### PR DESCRIPTION
Another discovered issue is with converting zero-ended hex to hex in an array. The reason was cutting all zeroes in hex string values.

For example:
`echo {0xf0} | dotnet run -- -f array -t array`
Returns:
{0xf}

This changes the resulting value of hex from 240(decimal) to 15(decimal). 

We are also not sure if this implementation is accepting hex characters correctly. It will not accept, for example, {0x1} on input while the output of {0x01} results in this value. But since it is not explicitly stated in the assignment, we are not sure what the correct output should be. 