### PR TITLE
fix: Only delimiters split code #4

### DIFF
--- a/src/CLI/InputProcessor.cs
+++ b/src/CLI/InputProcessor.cs
@@ -24,7 +24,7 @@ public class InputProcessor
     public void ProcessInput()
     {
         string? inputLine;
-        var delimiter = cliArgs.delimiter ?? "\n";
+        var delimiter = cliArgs.delimiter ?? Environment.NewLine;
 
         while (inputReader.DoesReaderHaveAdditionalInput() && (inputLine = inputReader.ReadUntilDelimiter(delimiter)) != null)
         {

--- a/src/CLI/InputProcessor.cs
+++ b/src/CLI/InputProcessor.cs
@@ -24,33 +24,31 @@ public class InputProcessor
     public void ProcessInput()
     {
         string? inputLine;
+        var delimiter = cliArgs.delimiter ?? "\n";
 
-        while ((inputLine = inputReader.ReadLine()) != null)
+        while (inputReader.DoesReaderHaveAdditionalInput() && (inputLine = inputReader.ReadUntilDelimiter(delimiter)) != null)
         {
-            string[] inputs = inputLine.Split(cliArgs.delimiter);
+            
+            string inputs = inputLine.TrimEnd(delimiter.ToCharArray());
             StringBuilder outputLine = new StringBuilder();
 
-            for (int i = 0; i < inputs.Length; i++)
+            if (cliArgs.inputFormat == Format.Array && cliArgs.outputFormat == Format.Array)
             {
-                if (cliArgs.inputFormat == Format.Array && cliArgs.outputFormat == Format.Array)
-                {
-                    ArrayValidator.CheckCorrectNesting(inputs[i]);
-                    ArrayValidator.CheckValidPosition(inputs[i]);
-                    outputLine.Append(ProcessNestedArray(inputs[i]));
-                }
-                else
-                {
-                    outputLine.Append(ProcessLine(inputs[i]));
-                }
-
-
-                if (i != inputs.Length - 1 && cliArgs.delimiter != null)
-                {
-                    outputLine.Append(cliArgs.delimiter);
-                }
+                ArrayValidator.CheckCorrectNesting(inputs);
+                ArrayValidator.CheckValidPosition(inputs);
+                outputLine.Append(ProcessNestedArray(inputs));
+            }
+            else
+            {
+                outputLine.Append(ProcessLine(inputs));
             }
 
-            outputWriter.WriteLine(outputLine.ToString());
+            if (inputReader.DoesReaderHaveAdditionalInput())
+            {
+                outputLine.Append(cliArgs.delimiter);
+            }
+
+            outputWriter.WriteOut(outputLine.ToString());
         }
 
         inputReader.Close();

--- a/src/CLI/InputProcessor.cs
+++ b/src/CLI/InputProcessor.cs
@@ -49,7 +49,7 @@ public class InputProcessor
 
             outputWriter.Write(outputLine.ToString());
         }
-
+        outputWriter.Write(Environment.NewLine);
         inputReader.Close();
         outputWriter.Close();
     }

--- a/src/CLI/InputProcessor.cs
+++ b/src/CLI/InputProcessor.cs
@@ -28,27 +28,26 @@ public class InputProcessor
 
         while (inputReader.DoesReaderHaveAdditionalInput() && (inputLine = inputReader.ReadUntilDelimiter(delimiter)) != null)
         {
-            
-            string inputs = inputLine.TrimEnd(delimiter.ToCharArray());
+            string input = inputLine.TrimEnd(delimiter.ToCharArray());
             StringBuilder outputLine = new StringBuilder();
 
             if (cliArgs.inputFormat == Format.Array && cliArgs.outputFormat == Format.Array)
             {
-                ArrayValidator.CheckCorrectNesting(inputs);
-                ArrayValidator.CheckValidPosition(inputs);
-                outputLine.Append(ProcessNestedArray(inputs));
+                ArrayValidator.CheckCorrectNesting(input);
+                ArrayValidator.CheckValidPosition(input);
+                outputLine.Append(ProcessNestedArray(input));
             }
             else
             {
-                outputLine.Append(ProcessLine(inputs));
+                outputLine.Append(ProcessLine(input));
             }
 
             if (inputReader.DoesReaderHaveAdditionalInput())
             {
-                outputLine.Append(cliArgs.delimiter);
+                outputLine.Append(delimiter);
             }
 
-            outputWriter.WriteOut(outputLine.ToString());
+            outputWriter.Write(outputLine.ToString());
         }
 
         inputReader.Close();

--- a/src/CLI/InputProcessor.cs
+++ b/src/CLI/InputProcessor.cs
@@ -49,6 +49,7 @@ public class InputProcessor
 
             outputWriter.Write(outputLine.ToString());
         }
+
         outputWriter.Write(Environment.NewLine);
         inputReader.Close();
         outputWriter.Close();

--- a/src/CLI/InputReader.cs
+++ b/src/CLI/InputReader.cs
@@ -50,6 +50,7 @@ public class InputReader
     public bool DoesReaderHaveAdditionalInput()
     {
         var reader = fileReader ?? Console.In;
+
         return reader.Peek() >= 0;
     }
 }

--- a/src/CLI/InputReader.cs
+++ b/src/CLI/InputReader.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Panbyte.CLI;
 
 public class InputReader
@@ -19,16 +21,22 @@ public class InputReader
         }
     }
 
-    public string? ReadLine()
+    public string? ReadUntilDelimiter(String delimiter)
     {
-        if (fileReader != null)
-        {
-            return fileReader.ReadLine();
+        var sb = new StringBuilder();
+        var reader = fileReader ?? Console.In;
+        
+        while (reader.Peek() >= 0)
+        { 
+            sb.Append((char)reader.Read()); 
+            
+            if (sb.Length > delimiter.Length && sb.ToString().EndsWith(delimiter))
+            {
+                return sb.ToString(); 
+            }
         }
-        else
-        {
-            return Console.ReadLine();
-        }
+        
+        return sb.ToString();
     }
 
     public void Close()
@@ -37,5 +45,11 @@ public class InputReader
         {
             fileReader.Close();
         }
+    }
+
+    public bool DoesReaderHaveAdditionalInput()
+    {
+        var reader = fileReader ?? Console.In;
+        return reader.Peek() >= 0;
     }
 }

--- a/src/CLI/OutputWriter.cs
+++ b/src/CLI/OutputWriter.cs
@@ -19,16 +19,10 @@ public class OutputWriter
         }
     }
 
-    public void WriteLine(string line)
+    public void WriteOut(string line)
     {
-        if (fileWriter != null)
-        {
-            fileWriter.WriteLine(line);
-        }
-        else
-        {
-            Console.WriteLine(line);
-        }
+        var writer = fileWriter ?? Console.Out;
+        writer.Write(line);
     }
 
     public void Close()

--- a/src/CLI/OutputWriter.cs
+++ b/src/CLI/OutputWriter.cs
@@ -19,9 +19,10 @@ public class OutputWriter
         }
     }
 
-    public void WriteOut(string line)
+    public void Write(string line)
     {
         var writer = fileWriter ?? Console.Out;
+
         writer.Write(line);
     }
 

--- a/tests/CLI/InputProcessorTest.cs
+++ b/tests/CLI/InputProcessorTest.cs
@@ -21,7 +21,7 @@ namespace tests.CLI
 
             inputProcessor.ProcessInput();
 
-            Assert.AreEqual("00000001x00000010", stringWriter.ToString());
+            Assert.AreEqual("00000001x00000010" + Environment.NewLine, stringWriter.ToString());
         }
 
         [TestMethod]
@@ -39,7 +39,7 @@ namespace tests.CLI
 
             inputProcessor.ProcessInput();
 
-            Assert.AreEqual("00000001" + Environment.NewLine + "00000010", stringWriter.ToString());
+            Assert.AreEqual("00000001" + Environment.NewLine + "00000010" + Environment.NewLine, stringWriter.ToString());
         }
 
         [TestMethod]
@@ -57,7 +57,7 @@ namespace tests.CLI
 
             inputProcessor.ProcessInput();
 
-            Assert.AreEqual("12", stringWriter.ToString());
+            Assert.AreEqual("12" + Environment.NewLine, stringWriter.ToString());
         }
     }
 }

--- a/tests/CLI/InputProcessorTest.cs
+++ b/tests/CLI/InputProcessorTest.cs
@@ -1,0 +1,63 @@
+﻿using Panbyte.CLI;
+using Panbyte.Structs;
+
+namespace tests.CLI
+{
+    [TestClass]
+    public class InputProcessorTest
+    {
+        [TestMethod]
+        public void InputProcessorProcessesInputWithSetDelimiter()
+        {
+            Arguments arguments = new Arguments(Panbyte.Enums.Format.Int,
+                new(), Panbyte.Enums.Format.Bits, new(), null, null, "x");
+            string input = "1x2";
+
+            StringReader stringReader = new(input);
+            Console.SetIn(stringReader);
+            StringWriter stringWriter = new();
+            Console.SetOut(stringWriter);
+            InputProcessor inputProcessor = new(arguments);
+
+            inputProcessor.ProcessInput();
+
+            Assert.AreEqual("00000001x00000010", stringWriter.ToString());
+        }
+
+        [TestMethod]
+        public void InputProcessorProcessesInputNoDelimiterDefaultsNewLine()
+        {
+            Arguments arguments = new Arguments(Panbyte.Enums.Format.Int,
+                new(), Panbyte.Enums.Format.Bits, new(), null, null, null);
+            string input = "1" + Environment.NewLine + "2";
+
+            StringReader stringReader = new(input);
+            Console.SetIn(stringReader);
+            StringWriter stringWriter = new();
+            Console.SetOut(stringWriter);
+            InputProcessor inputProcessor = new(arguments);
+
+            inputProcessor.ProcessInput();
+
+            Assert.AreEqual("00000001" + Environment.NewLine + "00000010", stringWriter.ToString());
+        }
+
+        [TestMethod]
+        public void InputProcessorProcessesInputDelimiterNotInInput()
+        {
+            Arguments arguments = new Arguments(Panbyte.Enums.Format.Int,
+                new(), Panbyte.Enums.Format.Int, new(), null, null, null);
+            string input = "12";
+
+            StringReader stringReader = new(input);
+            Console.SetIn(stringReader);
+            StringWriter stringWriter = new();
+            Console.SetOut(stringWriter);
+            InputProcessor inputProcessor = new(arguments);
+
+            inputProcessor.ProcessInput();
+
+            Assert.AreEqual("12", stringWriter.ToString());
+        }
+    }
+}

--- a/tests/CLI/InputReaderTest.cs
+++ b/tests/CLI/InputReaderTest.cs
@@ -1,0 +1,77 @@
+﻿using Panbyte.CLI;
+
+namespace tests.CLI
+{
+    [TestClass]
+    public class InputReaderTest
+    {
+        [TestMethod]
+        public void InputReaderEndsOnDelimiter()
+        {
+            string input = "Hello World!";
+
+            StringReader stringReader = new(input);
+            Console.SetIn(stringReader);
+
+            StringWriter stringWriter = new();
+            Console.SetOut(stringWriter);
+
+            InputReader inputReader = new(null);
+
+            var result = inputReader.ReadUntilDelimiter("World");
+            Assert.AreEqual("Hello World", result);
+        }
+
+        [TestMethod]
+        public void InputReaderReadsAllOnNoDelimiterIncluded()
+        {
+            string input = "Hello World!";
+
+            StringReader stringReader = new(input);
+            Console.SetIn(stringReader);
+
+            StringWriter stringWriter = new();
+            Console.SetOut(stringWriter);
+
+            InputReader inputReader = new(null);
+
+            var result = inputReader
+                .ReadUntilDelimiter("I am not inside that string for sure.");
+            Assert.AreEqual(input, result);
+        }
+
+        [TestMethod]
+        public void InputReaderHasAdditionalInputOnNonEmptyInput()
+        {
+            string input = "Hello World!";
+
+            StringReader stringReader = new(input);
+            Console.SetIn(stringReader);
+
+            StringWriter stringWriter = new();
+            Console.SetOut(stringWriter);
+
+            InputReader inputReader = new(null);
+
+            var result = inputReader.DoesReaderHaveAdditionalInput();
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void InputReaderHasAdditionalInputOnEmptyInput()
+        {
+            string input = "";
+
+            StringReader stringReader = new(input);
+            Console.SetIn(stringReader);
+
+            StringWriter stringWriter = new();
+            Console.SetOut(stringWriter);
+
+            InputReader inputReader = new(null);
+
+            var result = inputReader.DoesReaderHaveAdditionalInput();
+            Assert.IsFalse(result);
+        }
+    }
+}

--- a/tests/CLI/OutputWriterTest.cs
+++ b/tests/CLI/OutputWriterTest.cs
@@ -1,0 +1,25 @@
+﻿using Panbyte.CLI;
+
+namespace tests.CLI
+{
+    [TestClass]
+    public class OutputWriterTest
+    {
+        [TestMethod]
+        public void InputReaderEndsOnDelimiter()
+        {
+            string input = "Hello World!";
+
+            StringReader stringReader = new(input);
+            Console.SetIn(stringReader);
+
+            StringWriter stringWriter = new();
+            Console.SetOut(stringWriter);
+
+            OutputWriter outputWriter = new(null);
+
+            outputWriter.Write(input);
+            Assert.AreEqual(input, stringWriter.ToString());
+        }
+    }
+}

--- a/tests/Convertors/IntConvertorTests.cs
+++ b/tests/Convertors/IntConvertorTests.cs
@@ -1,3 +1,6 @@
+using Panbyte.CLI;
+using Panbyte.Structs;
+
 namespace Panbyte.Tests.Convertors;
 using Panbyte.Convertors;
 using Panbyte.Enums;
@@ -56,5 +59,23 @@ public class IntConvertorTest
         string input = "1234567890";
         string result = Convertor.ConvertToInt(InputConvertor.ConvertInt(uint.Parse(input), Endianity.Big));
         Assert.AreEqual("1234567890", result);
+    }
+    
+    [TestMethod]
+    public void ConvertIntToIntWithFaultyDelimiter()
+    {
+        Arguments arguments = new Arguments(Panbyte.Enums.Format.Int, new(), Panbyte.Enums.Format.Int, new(), null,
+            null, "x");
+
+        string input = "1\n2x12";
+        
+        StringReader stringReader = new StringReader(input);
+        Console.SetIn(stringReader);
+
+        StringWriter stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+        InputProcessor inputProcessor = new InputProcessor(arguments);
+        
+        Assert.ThrowsException<FormatException>(()=>inputProcessor.ProcessInput());
     }
 }


### PR DESCRIPTION
The program did not only split by provided delimiter but also by new lines. 

**For example:** 
Input provided from a file containing:
>12345
>67890
>12345x67890

with command: `dotnet run -- -f int -t hex -i in.txt -d x`
**Resulted in:**
>3039
>010932
>3039x010932

This behaviour is wrong since the provided delimiter is x. Therefore, the program should throw an exception and end with a non-zero exit code. And that's because a new line should be treated the same as other characters.